### PR TITLE
feat: Sprint1 크롤링 모듈 및 FastAPI 연동 closes #7 #8 #9 #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+output.json
+*_dump.html
+debug_room.py

--- a/eclass_crawler/crawler.py
+++ b/eclass_crawler/crawler.py
@@ -1,0 +1,270 @@
+"""
+E-class 크롤러 — 로컬 실행 전용
+eclass.tukorea.ac.kr
+
+실행: python crawler.py <학번> <비밀번호>
+결과: output.json
+"""
+
+import requests
+from bs4 import BeautifulSoup
+import json
+import sys
+import re
+
+BASE_URL = "https://eclass.tukorea.ac.kr"
+
+
+class EclassCrawler:
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "ko-KR,ko;q=0.9",
+        })
+        self._main_html = ""
+        self._user_id = ""
+
+    # ── 1. 로그인 ────────────────────────────────────────────────
+    def login(self, user_id: str, password: str) -> bool:
+        self._user_id = user_id
+        self.session.get(f"{BASE_URL}/ilos/main/main_form.acl", timeout=10)
+        form_resp = self.session.get(
+            f"{BASE_URL}/ilos/main/member/login_form.acl", timeout=10
+        )
+        soup = BeautifulSoup(form_resp.text, "html.parser")
+        challenge_el = soup.find("input", {"name": "challenge"})
+        challenge = challenge_el.get("value", "") if challenge_el else ""
+
+        self.session.headers.update({
+            "Referer": f"{BASE_URL}/ilos/main/member/login_form.acl",
+            "Origin": BASE_URL,
+            "Content-Type": "application/x-www-form-urlencoded",
+        })
+        resp = self.session.post(
+            f"{BASE_URL}/ilos/lo/login.acl",
+            data={"returnURL": "", "challenge": challenge, "response": "",
+                  "usr_id": user_id, "usr_pwd": password},
+            timeout=10, allow_redirects=False
+        )
+        try:
+            r = resp.json()
+            if not r.get("isError", True):
+                main = self.session.get(f"{BASE_URL}/ilos/main/main_form.acl", timeout=10)
+                self._main_html = main.text
+                print("✅ 로그인 성공")
+                return True
+            print(f"❌ 로그인 실패: {r.get('message','')}")
+            return False
+        except Exception:
+            pass
+
+        if "main_form.acl" in resp.text or resp.status_code in (301, 302):
+            main = self.session.get(f"{BASE_URL}/ilos/main/main_form.acl", timeout=10)
+            if "로그아웃" in main.text:
+                self._main_html = main.text
+                print("✅ 로그인 성공")
+                return True
+
+        print("❌ 로그인 실패")
+        return False
+
+    # ── 2. 수강 과목 목록 ────────────────────────────────────────
+    def get_courses(self) -> list:
+        soup = BeautifulSoup(self._main_html, "html.parser")
+        courses = []
+        for em in soup.find_all("em", class_="sub_open"):
+            kjkey = em.get("kj", "").strip()
+            if not kjkey or not kjkey.startswith("A"):
+                continue
+            raw = re.sub(r'\s+', ' ', em.get_text(separator=" ", strip=True))
+            m = re.match(r"(.+?)\s*\((\d+)\)\s*$", raw)
+            name = m.group(1).strip() if m else raw
+            section = m.group(2) if m else ""
+            span = em.find_next_sibling("span")
+            schedule = re.sub(r'\s+', ' ', span.get_text(strip=True)) if span else ""
+            lm = re.match(r"[A-Z](\d{4})(\d)([A-Z]{3}\d{5})(\d{2})$", kjkey)
+            lssn_cd = lm.group(3) if lm else ""
+            courses.append({
+                "kjkey": kjkey,
+                "name": name,
+                "section": section,
+                "lssn_cd": lssn_cd,
+                "schedule": schedule,
+            })
+        print(f"   수강 과목 {len(courses)}개")
+        for c in courses:
+            print(f"   - {c['name']} ({c['section']}분반) | {c['schedule']}")
+        return courses
+
+    # ── 3. 과목방 진입 ───────────────────────────────────────────
+    def enter_course(self, kjkey: str) -> str:
+        """과목방 진입 후 submain URL 반환"""
+        self.session.headers.update({
+            "Referer": f"{BASE_URL}/ilos/main/main_form.acl",
+            "X-Requested-With": "XMLHttpRequest",
+            "Accept": "application/json, */*",
+            "Content-Type": "application/x-www-form-urlencoded",
+        })
+        room_resp = self.session.post(
+            f"{BASE_URL}/ilos/st/course/eclass_room2.acl",
+            data={"KJKEY": kjkey, "returnData": "json",
+                  "returnURI": "/ilos/st/course/submain_form.acl", "encoding": "utf-8"},
+            timeout=10
+        )
+        return_url = room_resp.json().get("returnURL", "")
+        full_url = (BASE_URL + return_url) if not return_url.startswith("http") else return_url
+        if "KJKEY" not in full_url:
+            full_url += f"?KJKEY={kjkey}"
+
+        self.session.headers.update({
+            "X-Requested-With": "",
+            "Accept": "text/html,*/*",
+            "Referer": f"{BASE_URL}/ilos/main/main_form.acl",
+        })
+        self.session.get(full_url, timeout=10)
+        # Referer에 사용할 때 한글 없는 고정 URL 반환
+        return f"{BASE_URL}/ilos/st/course/submain_form.acl"
+
+    # ── 4. 과제 목록 (report_list.acl) ───────────────────────────
+    def get_assignments(self, kjkey: str, course_name: str) -> list:
+        self.enter_course(kjkey)
+
+        # report_list.acl — 파라미터: ud(학번), ky(kjkey)
+        self.session.headers.update({
+            "Referer": f"{BASE_URL}/ilos/st/course/submain_form.acl",
+            "X-Requested-With": "XMLHttpRequest",
+            "Accept": "text/html, */*",
+            "Content-Type": "application/x-www-form-urlencoded",
+        })
+        resp = self.session.post(
+            f"{BASE_URL}/ilos/st/course/report_list.acl",
+            data={
+                "start": "1",
+                "display": "100",
+                "SCH_VALUE": "",
+                "ud": self._user_id,
+                "ky": kjkey,
+                "encoding": "utf-8",
+            },
+            timeout=10
+        )
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        assignments = []
+        for row in soup.select("table tbody tr"):
+            # 제목: .subjt_top
+            title_el = row.select_one(".subjt_top")
+            if not title_el:
+                # 대안: td a
+                title_el = row.select_one("td.left a")
+            if not title_el:
+                continue
+
+            cols = row.select("td")
+            # 마감일: 보통 뒤에서 2번째 td
+            due_date = ""
+            for col in cols:
+                text = col.text.strip()
+                # 날짜 패턴 매칭
+                if re.search(r'\d{4}\.\d{2}\.\d{2}', text):
+                    due_date = text
+            is_submitted = "제출완료" in row.text or "제출" in row.text
+
+            assignments.append({
+                "kjkey": kjkey,
+                "course_name": course_name,
+                "title": title_el.text.strip(),
+                "due_date": due_date,
+                "is_submitted": is_submitted,
+                "type": "assignment",
+            })
+        return assignments
+
+    # ── 5. 공지사항 (notice_list.acl) ────────────────────────────
+    def get_notices(self, kjkey: str, course_name: str) -> list:
+        self.enter_course(kjkey)
+
+        self.session.headers.update({
+            "Referer": f"{BASE_URL}/ilos/st/course/submain_form.acl",
+            "X-Requested-With": "XMLHttpRequest",
+            "Accept": "text/html, */*",
+            "Content-Type": "application/x-www-form-urlencoded",
+        })
+        resp = self.session.post(
+            f"{BASE_URL}/ilos/st/course/notice_list.acl",
+            data={"KJKEY": kjkey, "encoding": "utf-8"},
+            timeout=10
+        )
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        notices = []
+        for row in soup.select("table tbody tr"):
+            title_el = row.select_one(".subjt_top")
+            if not title_el:
+                continue
+            cols = row.select("td")
+            notices.append({
+                "kjkey": kjkey,
+                "course_name": course_name,
+                "title": title_el.text.strip(),
+                "date": cols[-1].text.strip() if cols else "",
+                "type": "notice",
+            })
+        return notices
+
+    # ── 6. 전체 수집 ─────────────────────────────────────────────
+    def crawl_all(self, user_id: str, password: str) -> dict:
+        print("\n=== E-class 크롤링 시작 ===\n")
+        if not self.login(user_id, password):
+            return {"success": False}
+
+        print("\n[1] 수강 과목 목록 수집 중...")
+        courses = self.get_courses()
+        if not courses:
+            return {"success": False}
+
+        print(f"\n[2] 과제/공지 수집 중... (총 {len(courses)}개 과목)")
+        all_assignments, all_notices = [], []
+        for i, course in enumerate(courses):
+            kjkey = course["kjkey"]
+            name = course["name"]
+            print(f"   [{i+1}/{len(courses)}] {name} ({course['section']}분반)")
+            assignments = self.get_assignments(kjkey, name)
+            notices = self.get_notices(kjkey, name)
+            print(f"         과제 {len(assignments)}개, 공지 {len(notices)}개")
+            all_assignments += assignments
+            all_notices += notices
+
+        result = {
+            "success": True,
+            "data": {
+                "courses": courses,
+                "assignments": all_assignments,
+                "notices": all_notices,
+            }
+        }
+
+        with open("output.json", "w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+
+        print(f"\n✅ 완료!")
+        print(f"   수강 과목: {len(courses)}개")
+        print(f"   과제:      {len(all_assignments)}개")
+        print(f"   공지:      {len(all_notices)}개")
+        print(f"   → output.json 저장됨")
+        return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("사용법: python crawler.py <학번> <비밀번호>")
+        sys.exit(1)
+
+    crawler = EclassCrawler()
+    crawler.crawl_all(sys.argv[1], sys.argv[2])

--- a/tino_plan_backend/main.py
+++ b/tino_plan_backend/main.py
@@ -1,0 +1,41 @@
+"""
+Tino Plan — FastAPI 백엔드
+Sprint 1: E-class 크롤링 API
+Sprint 2: 캘린더 일정 CRUD API
+
+실행: uvicorn main:app --reload --port 8000
+"""
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from routers import eclass, calendar
+
+app = FastAPI(
+    title="Tino Plan API",
+    description="한국공학대 수강신청 플래너 및 학사 캘린더 API",
+    version="1.0.0",
+)
+
+# CORS 설정 (React 개발 서버 허용)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 라우터 등록
+app.include_router(eclass.router)
+app.include_router(calendar.router)
+
+
+@app.get("/")
+def root():
+    return {"message": "Tino Plan API", "version": "1.0.0"}
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/tino_plan_backend/requirements.txt
+++ b/tino_plan_backend/requirements.txt
@@ -1,0 +1,6 @@
+requests==2.31.0
+beautifulsoup4==4.12.3
+lxml==5.1.0
+fastapi==0.110.0
+uvicorn==0.27.1
+pydantic==2.6.1

--- a/tino_plan_backend/routers/calendar.py
+++ b/tino_plan_backend/routers/calendar.py
@@ -1,0 +1,110 @@
+"""
+Sprint 2: 캘린더 개인 일정 CRUD API 라우터
+- GET    /api/calendar/events
+- POST   /api/calendar/events
+- PUT    /api/calendar/events/{event_id}
+- DELETE /api/calendar/events/{event_id}
+"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+import uuid
+
+router = APIRouter(prefix="/api/calendar", tags=["Sprint2 - 캘린더"])
+
+# 인메모리 저장소 (실제 서비스에서는 DB로 교체)
+_events: dict[str, dict] = {}
+
+
+# ── 요청/응답 모델 ────────────────────────────────────────────────
+
+class EventCreate(BaseModel):
+    user_id: str
+    title: str
+    subject: Optional[str] = ""
+    due_date: str          # ISO 8601: "2026-05-30T23:59:00"
+    type: str = "personal" # personal | assignment | exam
+
+
+class EventUpdate(BaseModel):
+    title: Optional[str] = None
+    subject: Optional[str] = None
+    due_date: Optional[str] = None
+    type: Optional[str] = None
+
+
+class EventResponse(BaseModel):
+    id: str
+    user_id: str
+    title: str
+    subject: str
+    due_date: str
+    type: str
+    created_at: str
+
+
+# ── 헬퍼 ─────────────────────────────────────────────────────────
+
+def user_events(user_id: str) -> list[dict]:
+    return [e for e in _events.values() if e["user_id"] == user_id]
+
+
+# ── 엔드포인트 ───────────────────────────────────────────────────
+
+@router.get("/events", response_model=list[EventResponse], summary="개인 일정 목록 조회")
+async def get_events(user_id: str, type: Optional[str] = None):
+    """
+    사용자의 개인 일정 목록을 반환합니다.
+    type 파라미터로 personal / assignment / exam 필터링 가능합니다.
+    """
+    events = user_events(user_id)
+    if type:
+        events = [e for e in events if e["type"] == type]
+    return events
+
+
+@router.post("/events", response_model=EventResponse, status_code=201, summary="개인 일정 추가")
+async def create_event(event: EventCreate):
+    """새 개인 일정을 추가합니다."""
+    event_id = str(uuid.uuid4())
+    new_event = {
+        "id": event_id,
+        "user_id": event.user_id,
+        "title": event.title,
+        "subject": event.subject or "",
+        "due_date": event.due_date,
+        "type": event.type,
+        "created_at": datetime.now().isoformat(),
+    }
+    _events[event_id] = new_event
+    return new_event
+
+
+@router.put("/events/{event_id}", response_model=EventResponse, summary="개인 일정 수정")
+async def update_event(event_id: str, update: EventUpdate):
+    """기존 개인 일정을 수정합니다."""
+    event = _events.get(event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+
+    if update.title is not None:
+        event["title"] = update.title
+    if update.subject is not None:
+        event["subject"] = update.subject
+    if update.due_date is not None:
+        event["due_date"] = update.due_date
+    if update.type is not None:
+        event["type"] = update.type
+
+    return event
+
+
+@router.delete("/events/{event_id}", summary="개인 일정 삭제")
+async def delete_event(event_id: str):
+    """개인 일정을 삭제합니다."""
+    if event_id not in _events:
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+    del _events[event_id]
+    return {"success": True, "message": "삭제 완료"}

--- a/tino_plan_backend/routers/eclass.py
+++ b/tino_plan_backend/routers/eclass.py
@@ -1,0 +1,188 @@
+"""
+Sprint 1: E-class 크롤링 API 라우터
+- POST /api/eclass/login
+- GET  /api/eclass/courses
+- GET  /api/eclass/assignments
+- GET  /api/eclass/notices
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from typing import Optional
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../eclass_crawler"))
+from crawler import EclassCrawler
+
+router = APIRouter(prefix="/api/eclass", tags=["Sprint1 - E-class 크롤링"])
+
+# 메모리 세션 저장소 (실제 서비스에서는 Redis 등으로 교체)
+# key: user_id, value: EclassCrawler 인스턴스
+_sessions: dict[str, EclassCrawler] = {}
+
+
+# ── 요청/응답 모델 ────────────────────────────────────────────────
+
+class LoginRequest(BaseModel):
+    user_id: str
+    password: str
+
+class LoginResponse(BaseModel):
+    success: bool
+    message: str
+    user_id: str = ""
+
+class Course(BaseModel):
+    kjkey: str
+    name: str
+    section: str
+    lssn_cd: str
+    schedule: str
+
+class Assignment(BaseModel):
+    kjkey: str
+    course_name: str
+    title: str
+    due_date: str
+    is_submitted: bool
+    type: str = "assignment"
+
+class Notice(BaseModel):
+    kjkey: str
+    course_name: str
+    title: str
+    date: str
+    type: str = "notice"
+
+
+# ── 세션 검증 헬퍼 ───────────────────────────────────────────────
+
+def get_crawler(user_id: str) -> EclassCrawler:
+    crawler = _sessions.get(user_id)
+    if not crawler:
+        raise HTTPException(
+            status_code=401,
+            detail="로그인이 필요합니다. POST /api/eclass/login 먼저 호출하세요."
+        )
+    return crawler
+
+
+# ── 엔드포인트 ───────────────────────────────────────────────────
+
+@router.post("/login", response_model=LoginResponse, summary="E-class 로그인")
+async def login(req: LoginRequest):
+    """
+    E-class 로그인 후 세션을 서버에 저장합니다.
+    이후 요청에서 user_id를 쿼리 파라미터로 전달하여 세션을 식별합니다.
+    """
+    crawler = EclassCrawler()
+    success = crawler.login(req.user_id, req.password)
+
+    if not success:
+        raise HTTPException(status_code=401, detail="로그인 실패: 아이디 또는 비밀번호를 확인하세요.")
+
+    _sessions[req.user_id] = crawler
+    return LoginResponse(success=True, message="로그인 성공", user_id=req.user_id)
+
+
+@router.get("/courses", response_model=list[Course], summary="수강 과목 목록 조회")
+async def get_courses(user_id: str):
+    """
+    로그인한 사용자의 현재 학기 수강 과목 목록을 반환합니다.
+    main_form.acl HTML의 em.sub_open[kj] 선택자로 파싱합니다.
+    """
+    crawler = get_crawler(user_id)
+    courses = crawler.get_courses()
+    return courses
+
+
+@router.get("/assignments", response_model=list[Assignment], summary="전체 과제 목록 조회")
+async def get_assignments(user_id: str):
+    """
+    수강 중인 모든 과목의 과제 목록을 반환합니다.
+    report_list.acl 엔드포인트를 과목별로 호출하여 수집합니다.
+    """
+    crawler = get_crawler(user_id)
+    courses = crawler.get_courses()
+
+    all_assignments = []
+    for course in courses:
+        assignments = crawler.get_assignments(course["kjkey"], course["name"])
+        all_assignments.extend(assignments)
+
+    return all_assignments
+
+
+@router.get("/assignments/{kjkey}", response_model=list[Assignment], summary="특정 과목 과제 조회")
+async def get_course_assignments(kjkey: str, user_id: str):
+    """특정 과목(KJKEY)의 과제 목록을 반환합니다."""
+    crawler = get_crawler(user_id)
+    # kjkey로 과목명 찾기
+    courses = crawler.get_courses()
+    course = next((c for c in courses if c["kjkey"] == kjkey), None)
+    course_name = course["name"] if course else kjkey
+
+    return crawler.get_assignments(kjkey, course_name)
+
+
+@router.get("/notices", response_model=list[Notice], summary="전체 공지사항 조회")
+async def get_notices(user_id: str):
+    """
+    수강 중인 모든 과목의 공지사항을 반환합니다.
+    notice_list.acl 엔드포인트를 과목별로 호출하여 수집합니다.
+    """
+    crawler = get_crawler(user_id)
+    courses = crawler.get_courses()
+
+    all_notices = []
+    for course in courses:
+        notices = crawler.get_notices(course["kjkey"], course["name"])
+        all_notices.extend(notices)
+
+    return all_notices
+
+
+@router.get("/notices/{kjkey}", response_model=list[Notice], summary="특정 과목 공지사항 조회")
+async def get_course_notices(kjkey: str, user_id: str):
+    """특정 과목(KJKEY)의 공지사항을 반환합니다."""
+    crawler = get_crawler(user_id)
+    courses = crawler.get_courses()
+    course = next((c for c in courses if c["kjkey"] == kjkey), None)
+    course_name = course["name"] if course else kjkey
+
+    return crawler.get_notices(kjkey, course_name)
+
+
+@router.post("/sync", summary="전체 데이터 동기화")
+async def sync_all(user_id: str):
+    """
+    수강 과목 + 과제 + 공지를 한 번에 수집하여 반환합니다.
+    프론트엔드 초기 로딩 시 한 번 호출하는 용도입니다.
+    """
+    crawler = get_crawler(user_id)
+    courses = crawler.get_courses()
+
+    all_assignments, all_notices = [], []
+    for course in courses:
+        kjkey = course["kjkey"]
+        name = course["name"]
+        all_assignments.extend(crawler.get_assignments(kjkey, name))
+        all_notices.extend(crawler.get_notices(kjkey, name))
+
+    return {
+        "success": True,
+        "data": {
+            "courses": courses,
+            "assignments": all_assignments,
+            "notices": all_notices,
+        }
+    }
+
+
+@router.delete("/logout", summary="로그아웃 (세션 삭제)")
+async def logout(user_id: str):
+    """서버에서 세션을 삭제합니다."""
+    if user_id in _sessions:
+        del _sessions[user_id]
+    return {"success": True, "message": "로그아웃 완료"}

--- a/tino_plan_backend/test_crawler.py
+++ b/tino_plan_backend/test_crawler.py
@@ -1,0 +1,152 @@
+"""
+Sprint 1 단위 테스트
+E-class 크롤러 모듈 테스트
+
+실행: pytest test_crawler.py -v
+"""
+
+import pytest
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../eclass_crawler"))
+from crawler import EclassCrawler
+
+# ── 테스트용 자격증명 (환경변수에서 읽기) ─────────────────────────
+USER_ID = os.environ.get("ECLASS_USER_ID", "")
+PASSWORD = os.environ.get("ECLASS_PASSWORD", "")
+
+SKIP_REASON = "ECLASS_USER_ID / ECLASS_PASSWORD 환경변수 미설정"
+requires_auth = pytest.mark.skipif(not USER_ID, reason=SKIP_REASON)
+
+
+# ── TC-01: 크롤러 인스턴스 생성 ──────────────────────────────────
+def test_crawler_init():
+    """크롤러 인스턴스가 정상 생성되는지 확인"""
+    crawler = EclassCrawler()
+    assert crawler is not None
+    assert crawler.session is not None
+    assert crawler._user_id == ""
+    assert crawler._main_html == ""
+
+
+# ── TC-02: 로그인 성공 ───────────────────────────────────────────
+@requires_auth
+def test_login_success():
+    """올바른 자격증명으로 로그인 성공 확인"""
+    crawler = EclassCrawler()
+    result = crawler.login(USER_ID, PASSWORD)
+    assert result is True
+    assert crawler._main_html != ""
+    assert "로그아웃" in crawler._main_html
+
+
+# ── TC-03: 로그인 실패 ───────────────────────────────────────────
+def test_login_failure():
+    """잘못된 자격증명으로 로그인 실패 확인"""
+    crawler = EclassCrawler()
+    result = crawler.login("wrong_id", "wrong_pw")
+    assert result is False
+
+
+# ── TC-04: 수강 과목 목록 파싱 ──────────────────────────────────
+@requires_auth
+def test_get_courses():
+    """수강 과목 목록이 1개 이상 반환되는지 확인"""
+    crawler = EclassCrawler()
+    crawler.login(USER_ID, PASSWORD)
+    courses = crawler.get_courses()
+
+    assert isinstance(courses, list)
+    assert len(courses) >= 1
+
+    # 각 과목이 필수 필드를 가지는지 확인
+    for course in courses:
+        assert "kjkey" in course
+        assert "name" in course
+        assert "section" in course
+        assert "schedule" in course
+        assert course["kjkey"].startswith("A")  # 정규과목
+        assert len(course["name"]) > 0
+
+
+# ── TC-05: 과목 KJKEY 형식 검증 ─────────────────────────────────
+@requires_auth
+def test_kjkey_format():
+    """KJKEY가 올바른 형식인지 확인 (예: A20261ACS1002201)"""
+    import re
+    crawler = EclassCrawler()
+    crawler.login(USER_ID, PASSWORD)
+    courses = crawler.get_courses()
+
+    pattern = re.compile(r"^[A-Z]\d{4}\d[A-Z]{3}\d{5}\d{2}$")
+    for course in courses:
+        assert pattern.match(course["kjkey"]), \
+            f"KJKEY 형식 오류: {course['kjkey']}"
+
+
+# ── TC-06: 과제 목록 수집 ───────────────────────────────────────
+@requires_auth
+def test_get_assignments():
+    """특정 과목(유닉스기초)의 과제 목록 수집 확인"""
+    crawler = EclassCrawler()
+    crawler.login(USER_ID, PASSWORD)
+    courses = crawler.get_courses()
+
+    # 유닉스기초 과목 찾기
+    target = next((c for c in courses if "유닉스" in c["name"]), None)
+    if not target:
+        pytest.skip("유닉스기초 과목 없음")
+
+    assignments = crawler.get_assignments(target["kjkey"], target["name"])
+    assert isinstance(assignments, list)
+
+    for a in assignments:
+        assert "title" in a
+        assert "due_date" in a
+        assert "is_submitted" in a
+        assert "course_name" in a
+        assert a["type"] == "assignment"
+
+
+# ── TC-07: 공지사항 수집 ────────────────────────────────────────
+@requires_auth
+def test_get_notices():
+    """특정 과목(유닉스기초)의 공지사항 수집 확인"""
+    crawler = EclassCrawler()
+    crawler.login(USER_ID, PASSWORD)
+    courses = crawler.get_courses()
+
+    target = next((c for c in courses if "유닉스" in c["name"]), None)
+    if not target:
+        pytest.skip("유닉스기초 과목 없음")
+
+    notices = crawler.get_notices(target["kjkey"], target["name"])
+    assert isinstance(notices, list)
+    assert len(notices) >= 1  # 유닉스기초는 공지가 있음을 확인
+
+    for n in notices:
+        assert "title" in n
+        assert "date" in n
+        assert "course_name" in n
+        assert n["type"] == "notice"
+
+
+# ── TC-08: 전체 수집 통합 테스트 ────────────────────────────────
+@requires_auth
+def test_crawl_all():
+    """전체 크롤링 결과가 올바른 형식인지 확인"""
+    crawler = EclassCrawler()
+    result = crawler.crawl_all(USER_ID, PASSWORD)
+
+    assert result["success"] is True
+    assert "data" in result
+
+    data = result["data"]
+    assert "courses" in data
+    assert "assignments" in data
+    assert "notices" in data
+
+    assert len(data["courses"]) >= 1
+    # 최소 1개 과목에 공지 있음
+    assert len(data["notices"]) >= 1


### PR DESCRIPTION
## Sprint 1 — E-class 크롤링 모듈 및 FastAPI 연동

### 구현 내용
- E-class 로그인 모듈 (POST /ilos/lo/login.acl)
- 수강 과목 목록 파싱 (main_form.acl, em.sub_open[kj] 선택자)
- 과제 목록 수집 (POST /ilos/st/course/report_list.acl)
- 공지사항 수집 (POST /ilos/st/course/notice_list.acl)
- FastAPI 라우터: /api/eclass, /api/calendar
- 단위 테스트: test_crawler.py

### 테스트 결과
- 수강 과목 7개 정상 수집
- 과제 44개, 공지 39개 정상 수집
- TC-01 ~ TC-08 전체 PASS

### 관련 이슈
closes #7 closes #8 closes #9 closes #10